### PR TITLE
CMake and OpenBSD support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.27)
+project(picat
+        LANGUAGES C CXX
+        VERSION 7.3
+)
+
+include(GNUInstallDirs)
+
+if(DEFINED OPENBSD_LOCALBASE)
+    include_directories(${OPENBSD_LOCALBASE}/include)
+    link_directories(${OPENBSD_LOCALBASE}/lib)
+endif()
+
+set(CMAKE_MODULE_PATH
+        ${CMAKE_CURRENT_LIST_DIR}/cmake
+        ${CMAKE_MODULE_PATH}
+)
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+        set(SYSTEM_NAME "OPENBSD")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        set(SYSTEM_NAME "LINUX")
+else()
+        message(FATAL_ERROR "Unsupported system: ${CMAKE_SYSTEM_NAME}")
+endif()
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(64BITS M64BITS)
+    message(STATUS "Set 64bit")
+endif ()
+
+add_compile_definitions(unix POSIX ${SYSTEM_NAME} GC PICAT SAT ${64BITS})
+add_compile_options(-O3 -fno-strict-aliasing -finline-functions -fomit-frame-pointer -Wno-error=unused-label)
+
+add_subdirectory(emu)

--- a/emu/CMakeLists.txt
+++ b/emu/CMakeLists.txt
@@ -1,0 +1,24 @@
+
+set(HEADERS
+        bapi.h bprolog_cg_cgevent.h build.h dynamic.h extern_decl.h gc.h kapi.h load_inst.h picat.h sapi.h basicd.h
+        bprolog.h clpfd.h emu_inst.h frame.h getline.h load_inst_frombplist.h maple_interface.h picat_utilities.h
+        term.h basic.h bprolog_plc_plc.h dis_inst.h event.h fzn_picat_smt_bc.h inst.h load_inst_fromcarray.h picat_bc.h
+        reasonls_interface.h toam.h
+)
+
+set(SOURCES
+        arith.c builtins.c clpfd_libs.c dis.c expand_bp.c float1.c getline.c init_sym.c main.c
+        toamprofile.c assert_bp.c cfd.c cpreds.c domain.c expand.c gcheap.c global.c
+        inst_inf.c kissat_picat.c mic.c table.c token.c assert.c clause.c debug.c espresso_bp.c file.c gcqueue.c
+        glpk_bp.c jmp_table.c loader.c numbervars.c sapi.c unify.c bigint.c clpfd.c delay.c event.c findall.c
+        gcstack.c init.c kapi.c load_inst.c picat_utilities.c toam.c univ.c
+)
+
+add_subdirectory(kissat)
+add_subdirectory(espresso)
+
+add_executable(picat ${HEADERS} ${SOURCES})
+target_link_libraries(picat PRIVATE m pthread espresso kissat)
+target_include_directories(picat PRIVATE "${CMAKE_SOURCE_DIR}/emu/espresso")
+
+install(TARGETS picat)

--- a/emu/espresso/CMakeLists.txt
+++ b/emu/espresso/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+set(HEADERS
+        copyright.h  espresso.h  main.h  mincov.h  mincov_int.h  port.h  signature.h  sparse.h  sparse_int.h  utility.h
+)
+
+set(SOURCES
+        black_white.c cols.c cpu_time.c cvrm.c dominate.c espresso_expand.c essentiality.c gimpel.c indep.c matrix.c
+        pair.c prtime.c set.c sigma.c sminterf.c unate.c canonical.c compl.c cubestr.c cvrmisc.c equiv.c
+        espresso_main.c exact.c globals.c irred.c mincov.c part.c reduce.c setc.c signature.c solution.c
+        util_signature.c cofactor.c contain.c cvrin.c cvrout.c espresso.c essen.c gasp.c hack.c map.c opo.c primes.c
+        rows.c sharp.c signature_exact.c sparse.c verify.c
+)
+
+add_library(espresso STATIC ${HEADERS} ${SOURCES})

--- a/emu/file.c
+++ b/emu/file.c
@@ -1843,10 +1843,15 @@ int get_socket_fd(int index) {
     printf("get_socket_fd not supported for non-Linux platforms\n");
     return 0;
 #else
+#ifdef __OpenBSD__
+    printf("get_socket_fd not supported for non-Linux platforms\n");
+    return 0;
+#else
 #if defined ANDROID || defined FREEBSD
     return(file_table[index].fdes->_file);
 #else
     return(file_table[index].fdes->_fileno);
+#endif
 #endif
 #endif
 #endif

--- a/emu/kissat/CMakeLists.txt
+++ b/emu/kissat/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(src)

--- a/emu/kissat/src/CMakeLists.txt
+++ b/emu/kissat/src/CMakeLists.txt
@@ -1,0 +1,27 @@
+
+set(HEADERS
+        allocate.h autarky.h clause.h deduce.h error.h frames.h inline.h kitten.h parse.h propdense.h reduce.h
+        resources.h strengthen.h value.h xors.h analyze.h averages.h clueue.h definition.h extend.h gates.h
+        inlineheap.h learn.h phases.h prophyper.h reference.h restart.h substitute.h vector.h ands.h backbone.h
+        collect.h dense.h failed.h handle.h inlinequeue.h limits.h print.h proplit.h reluctant.h search.h sweep.h
+        vivify.h application.h backtrack.h colors.h dominate.h fastassign.h heap.h inlinevector.h literal.h probe.h
+        proprobe.h rephase.h shrink.h terminate.h walk.h arena.h backward.h compact.h eliminate.h file.h ifthenelse.h
+        internal.h logging.h profile.h propsearch.h report.h smooth.h ternary.h warmup.h array.h build.h config.h
+        endianess.h flags.h import.h kimits.h minimize.h promote.h queue.h require.h sort.h trail.h watch.h assign.h
+        bump.h cover.h endianness.h format.h inlineassign.h kissat_bool.h mode.h proof.h random.h resize.h stack.h
+        transitive.h weaken.h attribute.h check.h decide.h equivalences.h forward.h inlineframes.h kissat.h options.h
+        propbeyond.h rank.h resolve.h statistics.h utilities.h witness.h
+)
+
+set(SOURCES
+        allocate.c analyze.c ands.c application.c arena.c assign.c autarky.c averages.c backtrack.c backward.c
+        build.c bump.c check.c clause.c clueue.c collect.c colors.c compact.c config.c decide.c deduce.c dense.c
+        dominate.c dump.c eliminate.c equivalences.c error.c extend.c failed.c file.c flags.c format.c forward.c
+        frames.c gates.c handle.c heap.c ifthenelse.c import.c internal.c learn.c limits.c logging.c main.c minimize.c
+        mode.c options.c parse.c phases.c print.c probe.c profile.c promote.c proof.c propdense.c prophyper.c
+        proprobe.c propsearch.c queue.c reduce.c reluctant.c rephase.c report.c resize.c resolve.c resources.c
+        restart.c search.c smooth.c sort.c stack.c statistics.c strengthen.c substitute.c terminate.c ternary.c
+        trail.c transitive.c utilities.c vector.c vivify.c walk.c watch.c weaken.c witness.c xors.c
+)
+
+add_library(kissat STATIC ${HEADERS} ${SOURCES})


### PR DESCRIPTION
This PR adds support for CMake on Linux and OpenBSD, except the `emu/fann` target.

In order to use it, CMake version 3.27 or higher is required.
Ninja is supported for faster builds.

Generate the build directory:
```
cmake -B build --install-prefix $HOME/Picat-3.9.4
#  Optionally, to use Ninja instead of make:
# cmake -B build --install-prefix $HOME/Picat-3.9.4 -GNinja
```

Build the project:
```
cmake --build build
```

Install the `picat` binary to the prefix directory given in the generate step:
```
cmake --install 
```

This PR also disables the `get_socket_fd` in `emu/file.c` for OpenBSD, since `FILE` is an opaque type on that platform.

